### PR TITLE
Multiple sensors + SPI + examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Arduino library for AllSensors DLHR Series Low Voltage Digital Pressure Sensors #
 
 This is an Arduino-compatible library for the [AllSensors DLHR Series Low Voltage Digital Pressure Sensors](https://www.allsensors.com/products/dlhr-series). The library currently supports I²C communications with the sensors.
+
+This forked proposes the following additions:
+
+* Add support for SPI (under development)
+* Add a non blocking code function: readDataAsynchro(), to multiplex sensors.
+    i2c multiplexing requires a multiplexer
+    spi multiplexing is underdevelopment

--- a/examples/ReadSensor/ReadMultipleSensors-i2c.ino
+++ b/examples/ReadSensor/ReadMultipleSensors-i2c.ino
@@ -1,0 +1,82 @@
+#include <Arduino.h>
+#include <Wire.h>
+#include <AllSensors_DLHR.h>
+
+#include <TI_TCA9548A.h>
+#define TCAADDR 0x70
+
+
+/*
+Multiple AllSensors DLHR using i2c  - 24/04/2024 - Sylvain Boyer
+_______________________________________________________________________________________________________________________________
+This example is using a forked of the library All Sensors from Jeremy Cole: https://github.com/sylvanoMTL/AllSensors_DLHR_multi
+The library has been modified with an asynchronous method that uses a state machine to avoid code blocking.
+For instance, if a sensor return a NaN, the other sensors are able to carry on their own pressure measurement.
+
+The uses of multiple sensors, having the i2c address tequire a multiplexer.
+This multiplexer is a TCA9548A from Texas instrument. 
+To operate the multiplexer, snippet code are available online. 
+
+Alternatively, this example is using the library https://github.com/jeremycole/TI_TCA9548A.git
+_______________________________________________________________________________________________________________________________
+
+*/
+
+
+//Uncomment this line to have a single sensor, keep commented
+//#define SINGLE_SENSOR
+
+
+TI_TCA9548A tca9548a(&Wire);
+
+#ifdef SINGLE_SENSOR
+  AllSensors_DLHR_F05D_8 gagePressure(&Wire);
+#else
+  AllSensors_DLHR_F05D_8 gagePressureArray[8] =  AllSensors_DLHR_F05D_8(&Wire);  
+  bool condition[8]={0};
+  float pressureArray[8]={0}; 
+
+#endif
+
+void setup() {
+    Wire.begin();
+    Serial.begin(115200);
+    
+    #ifdef SINGLE_SENSOR
+      gagePressure.setPressureUnit(AllSensors_DLHR::PressureUnit::PASCAL);
+    #else
+      for(byte i = 0;i<8;i++){
+      gagePressureArray[i].setPressureUnit(AllSensors_DLHR::PressureUnit::PASCAL);
+      }                                      
+    #endif
+}
+
+
+void loop(){
+    #ifdef SINGLE_SENSOR
+      tca9548a.selectChannel(1);
+      if(gagePressure.readDataAsynchro())
+      {
+            Serial.print("Pressure: ");
+            Serial.print(gagePressure.pressure);
+            Serial.print(" Temperature: ");
+            Serial.println(gagePressure.temperature);
+          }
+    #else
+      for(byte i = 0;i<8;i++){
+        tca9548a.selectChannel(i);
+        condition[i] = gagePressureArray[i].readDataAsynchro();
+        if(condition[i]){
+            pressureArray[i] = gagePressureArray[i].pressure;
+        }
+      }
+
+      for(byte i = 0;i<8;i++){
+        Serial.print(pressureArray[i]);Serial.print("\t");
+      }
+      Serial.println();
+    #endif
+}
+
+
+

--- a/examples/ReadSensor/ReadMultipleSensors-i2c.ino
+++ b/examples/ReadSensor/ReadMultipleSensors-i2c.ino
@@ -7,9 +7,9 @@
 
 
 /*
-Multiple AllSensors DLHR using i2c  - 24/04/2024 - Sylvain Boyer
+Multiple AllSensors DLHR using i2c  - 24/04/2022 - Sylvain Boyer
 _______________________________________________________________________________________________________________________________
-This example is using a forked of the library All Sensors from Jeremy Cole: https://github.com/sylvanoMTL/AllSensors_DLHR_multi
+This example is using a forked of the library All Sensors from Jeremy Cole: https://github.com/sylvanoMTL/AllSensors_DLHR
 The library has been modified with an asynchronous method that uses a state machine to avoid code blocking.
 For instance, if a sensor return a NaN, the other sensors are able to carry on their own pressure measurement.
 

--- a/examples/ReadSensor/ReadMultipleSensors-spi.ino
+++ b/examples/ReadSensor/ReadMultipleSensors-spi.ino
@@ -1,0 +1,103 @@
+#include <Arduino.h>
+#include <SPI.h>
+#include <AllSensors_DLHR.h>
+
+
+/*
+Multiple AllSensors DLHR using spi  - 26/04/2022 - Sylvain Boyer
+_______________________________________________________________________________________________________________________________
+This example is using a forked of the library All Sensors from Jeremy Cole: https://github.com/sylvanoMTL/AllSensors_DLHR
+The library has been modified with an asynchronous method that uses a state machine to avoid code blocking.
+For instance, if a sensor return a NaN, the other sensors are able to carry on their own pressure measurement.
+
+in this example:
+* the AllSensor DLHR is used using SPI bus. (note that not all DLHR have this capability, this is dependant of the sensor package)
+* the Chip Select pins of the DLHR sensor are pulled up to 3.3V using a 3.3 kOhm resistor
+* the Chip Select of the sensor is wired to pin 2,3,4 and 5
+* two modes are proposed: 
+        - single sensor: do the readings using the orginal functions from Jeremy Cole (modified for SPI)
+        - multiple sensor: do the readings using asynchronous functions
+_______________________________________________________________________________________________________________________________
+*/
+
+//Uncomment this line to have a single sensor, keep commented
+//#define SINGLE_SENSOR
+
+
+#ifdef SINGLE_SENSOR
+  #define CS_PIN 2          
+  AllSensors_DLHR_F05D_8 gagePressure(CS_PIN);
+#else
+  #define PRESSURE_0_CS_PIN 2
+  #define PRESSURE_1_CS_PIN 3
+  #define PRESSURE_2_CS_PIN 4
+  #define PRESSURE_3_CS_PIN 5
+  
+  const byte pressure_arrayLen = 4;
+  AllSensors_DLHR_F05D_8  gagepressure_array[pressure_arrayLen] ={  
+                                                                  AllSensors_DLHR_F05D_8(PRESSURE_0_CS_PIN),
+                                                                  AllSensors_DLHR_F05D_8(PRESSURE_1_CS_PIN),
+                                                                  AllSensors_DLHR_F05D_8(PRESSURE_2_CS_PIN),
+                                                                  AllSensors_DLHR_F05D_8(PRESSURE_3_CS_PIN)};
+
+
+  bool condition[pressure_arrayLen]={0};
+  float pressure[pressure_arrayLen];
+  float temperature[pressure_arrayLen];
+#endif
+
+
+
+
+void setup() {
+  #ifdef SINGLE_SENSOR
+    pinMode(CS_PIN, OUTPUT); // set the SS pin as an output
+    SPI.begin();         // initialize the SPI library
+    Serial.begin(115200);
+    gagePressure.begin();
+    gagePressure.setPressureUnit(AllSensors_DLHR::PressureUnit::PASCAL);
+  #else
+    SPI.begin();         // initialize the SPI library
+    for(byte i=0;i<pressure_arrayLen;i++){
+      gagepressure_array[i].begin();
+    }
+    for(byte i=0;i<pressure_arrayLen;i++){
+      gagepressure_array[i].setPressureUnit(AllSensors_DLHR::PressureUnit::PASCAL);
+    }
+    Serial.begin(115200);
+  #endif
+}
+
+void loop(){
+  #ifdef SINGLE_SENSOR
+    gagePressure.startMeasurement();
+    //Serial.println(gagePressure.readStatus());
+    gagePressure.readData(true);
+    Serial.print("Pressure: ");
+    Serial.print(gagePressure.pressure);
+    Serial.print(" Temperature: ");
+    Serial.println(gagePressure.temperature);
+    delay(20);
+  #else
+    // initiate the measurements and get results when available
+    for(byte i=0;i<pressure_arrayLen;i++){
+        condition[i]=gagepressure_array[i].readDataAsynchro_V2();
+        if(condition[i]) { 
+          pressure[i] = gagepressure_array[i].pressure;
+          temperature[i]=gagepressure_array[i].temperature;
+          condition[i]=0;
+        }
+    }
+
+    //print the results to the serial port
+    for(byte i=0;i<pressure_arrayLen;i++){
+        Serial.print(pressure[i]);Serial.print("\t");
+    }
+    for(byte i=0;i<pressure_arrayLen;i++){
+        Serial.print(temperature[i]);Serial.print("\t");
+    }
+    Serial.println();
+    delay(20);
+  #endif
+}
+

--- a/examples/ReadSensor/ReadMultipleSensors-spi.ino
+++ b/examples/ReadSensor/ReadMultipleSensors-spi.ino
@@ -81,7 +81,7 @@ void loop(){
   #else
     // initiate the measurements and get results when available
     for(byte i=0;i<pressure_arrayLen;i++){
-        condition[i]=gagepressure_array[i].readDataAsynchro_V2();
+        condition[i]=gagepressure_array[i].readDataAsynchro();
         if(condition[i]) { 
           pressure[i] = gagepressure_array[i].pressure;
           temperature[i]=gagepressure_array[i].temperature;

--- a/src/AllSensors_DLHR.cpp
+++ b/src/AllSensors_DLHR.cpp
@@ -15,6 +15,7 @@ See the LICENSE file for more details.
 #include <math.h>
 #include <util/delay.h>
 
+
 AllSensors_DLHR::AllSensors_DLHR(TwoWire *bus, SensorType type, SensorResolution pressure_resolution, float pressure_max) :
   pressure_unit(PressureUnit::IN_H2O),
   temperature_unit(TemperatureUnit::CELCIUS)
@@ -23,6 +24,7 @@ AllSensors_DLHR::AllSensors_DLHR(TwoWire *bus, SensorType type, SensorResolution
   this->type = type;
   this->pressure_resolution = pressure_resolution;
   this->pressure_max = pressure_max;
+  this->state = State::STATE0;
 
   // Produce bitmasks to mask out undefined bits of both sensors. The pressure sensor's resolution
   // depends on the purchased option (-6, -7, -8 for 16-, 17-, and 18-bit resolution respectively),
@@ -44,64 +46,197 @@ AllSensors_DLHR::AllSensors_DLHR(TwoWire *bus, SensorType type, SensorResolution
   }
 }
 
+
+AllSensors_DLHR::AllSensors_DLHR(uint8_t spi_cs, uint8_t spi_mosi,
+                                     uint8_t spi_miso, uint8_t spi_clk, SensorType type, SensorResolution pressure_resolution, float pressure_max)
+    : temperature_unit(TemperatureUnit::CELCIUS) {
+        this->_cs = spi_cs;
+        this->_mosi = spi_mosi;
+        this->_miso = spi_miso;
+        this->_sck = spi_clk;
+    this->bus = NULL;
+    this->type = type;
+    this->pressure_resolution = pressure_resolution;
+    this->pressure_max = pressure_max;
+    this->state = State::STATE0;
+
+    // Produce bitmasks to mask out undefined bits of both sensors. The pressure sensor's resolution
+    // depends on the purchased option (-6, -7, -8 for 16-, 17-, and 18-bit resolution respectively),
+    // and the temperature sensor is always 16-bit resolution. Note that the *lower* bits are the unused
+    // bits, so that it is the *UPPER* bits that should be kept and the lower ones discarded.
+    pressure_resolution_mask    = ~(((uint32_t) 1 << (FULL_SCALE_RESOLUTION - pressure_resolution)) - 1);
+    temperature_resolution_mask = ~(((uint32_t) 1 << (FULL_SCALE_RESOLUTION - TEMPERATURE_RESOLUTION)) - 1);
+
+    // Store a few scaling factors depending on the pressure sensor output type.
+    switch (type) {
+        case GAGE:
+        pressure_zero_ref = 0.1 * FULL_SCALE_REF;
+        pressure_range = pressure_max;
+        break;
+        case DIFFERENTIAL:
+        pressure_zero_ref = 0.5 * FULL_SCALE_REF;
+        pressure_range = pressure_max * 2;
+        break;
+    }
+}
+
+
+AllSensors_DLHR::AllSensors_DLHR(uint8_t spi_cs, SensorType type, SensorResolution pressure_resolution, float pressure_max):temperature_unit(TemperatureUnit::CELCIUS){
+    this->_cs = spi_cs;
+    this->bus = NULL;
+    this->type = type;
+    this->pressure_resolution = pressure_resolution;
+    this->pressure_max = pressure_max;
+    this->state = State::STATE0;
+
+    // Produce bitmasks to mask out undefined bits of both sensors. The pressure sensor's resolution
+    // depends on the purchased option (-6, -7, -8 for 16-, 17-, and 18-bit resolution respectively),
+    // and the temperature sensor is always 16-bit resolution. Note that the *lower* bits are the unused
+    // bits, so that it is the *UPPER* bits that should be kept and the lower ones discarded.
+    pressure_resolution_mask    = ~(((uint32_t) 1 << (FULL_SCALE_RESOLUTION - pressure_resolution)) - 1);
+    temperature_resolution_mask = ~(((uint32_t) 1 << (FULL_SCALE_RESOLUTION - TEMPERATURE_RESOLUTION)) - 1);
+
+    // Store a few scaling factors depending on the pressure sensor output type.
+    switch (type) {
+        case GAGE:
+        pressure_zero_ref = 0.1 * FULL_SCALE_REF;
+        pressure_range = pressure_max;
+        break;
+        case DIFFERENTIAL:
+        pressure_zero_ref = 0.5 * FULL_SCALE_REF;
+        pressure_range = pressure_max * 2;
+        break;
+    }
+}
+
+
+bool AllSensors_DLHR::begin(void){
+  if(bus == NULL ){ // SPI mode
+    pinMode(this->_cs, OUTPUT);
+    digitalWrite(this->_cs, HIGH);
+    this->state = State::STATE0;
+    //this->process_finished = 0;
+        //Serial.println("no SPI bus, invoking SPI.begin();...");
+        //SPI.setClockDivider(SPI_CLOCK_DIV16);
+        //SPI.begin();
+  }
+  else{}
+  return true;
+}
+
+
+
+
 void AllSensors_DLHR::startMeasurement(MeasurementType measurement_type) {
-  bus->beginTransmission(I2C_ADDRESS);
-  bus->write((uint8_t) measurement_type);
-  bus->write(0x00);
-  bus->write(0x00);
-  bus->endTransmission();
+    if(bus == NULL ){ // SPI mode
+        SPI.beginTransaction (SPISettings (2000000, MSBFIRST, SPI_MODE0));
+        digitalWrite (this->_cs, LOW);
+        SPI.transfer((uint8_t) measurement_type);
+        SPI.transfer(0x00);
+        SPI.transfer(0x00);
+        digitalWrite (this->_cs, HIGH);
+        SPI.endTransaction();
+    }
+    else{ //i2c mode
+        bus->beginTransmission(I2C_ADDRESS);
+        bus->write((uint8_t) measurement_type);
+        bus->write(0x00);
+        bus->write(0x00);
+        bus->endTransmission();
+    }
 }
 
 uint8_t AllSensors_DLHR::readStatus() {
-  bus->requestFrom(I2C_ADDRESS, READ_STATUS_LENGTH);
-  status = bus->read();
-  bus->endTransmission();
-
+    if(bus ==NULL ){// SPI mode 
+        SPI.beginTransaction (SPISettings (2000000, MSBFIRST, SPI_MODE0));
+        digitalWrite (this->_cs, LOW);
+            status = SPI.transfer(0xF0);
+            SPI.transfer(0x00);
+            SPI.transfer(0x00);
+        digitalWrite (this->_cs, HIGH);
+        SPI.endTransaction();
+    }
+    else{//i2c mode
+        bus->requestFrom(I2C_ADDRESS, READ_STATUS_LENGTH);
+        status = bus->read();
+        bus->endTransmission();
+    }
   return status;
 }
 
 bool AllSensors_DLHR::readData(bool wait) {
 try_again:
-  bus->requestFrom(I2C_ADDRESS, (uint8_t) (READ_STATUS_LENGTH + READ_PRESSURE_LENGTH + READ_TEMPERATURE_LENGTH));
+    if(bus ==NULL ){ //spi mode
+            SPI.beginTransaction (SPISettings (2000000, MSBFIRST, SPI_MODE0));
+            digitalWrite (this->_cs, LOW);
+            status = SPI.transfer(0xF0); 
+            if (isError(status)) {
+                // An ALU or memory error occurred.
+                digitalWrite (this->_cs, HIGH);
+                SPI.endTransaction();
+                goto error;
+            }
+            if (isBusy(status)) {
+                // The sensor is still busy; either retry or fail.
+                digitalWrite (this->_cs, HIGH);
+                SPI.endTransaction();
+                if (wait) {
+                // Wait just a bit so that we don't completely hammer the bus with retries.
+                _delay_us(100);
+                goto try_again;
+                }
+                goto error;
+            }
+            *((uint8_t *)(&raw_p)+2) = SPI.transfer(0x00);
+            *((uint8_t *)(&raw_p)+1) = SPI.transfer(0x00);
+            *((uint8_t *)(&raw_p)+0) = SPI.transfer(0x00);
 
-  // Read the 8-bit status data.
-  status = bus->read();
+            // Read the 24-bit (high 16 bits defined) of raw temperature data.
+            *((uint8_t *)(&raw_t)+2) = SPI.transfer(0x00);
+            *((uint8_t *)(&raw_t)+1) = SPI.transfer(0x00);
+            *((uint8_t *)(&raw_t)+0) = SPI.transfer(0x00);
 
-  if (isError(status)) {
-    // An ALU or memory error occurred.
-    bus->endTransmission();
-    goto error;
-  }
-
-  if (isBusy(status)) {
-    // The sensor is still busy; either retry or fail.
-    bus->endTransmission();
-
-    if (wait) {
-      // Wait just a bit so that we don't completely hammer the bus with retries.
-      _delay_us(100);
-      goto try_again;
+            digitalWrite (this->_cs, HIGH);
+        SPI.endTransaction();
+        pressure = convertPressure(transferPressure(raw_p & pressure_resolution_mask));
+        temperature = convertTemperature(transferTemperature(raw_t & temperature_resolution_mask));
+        return isError(status);
     }
+    else{   //i2c mode
+            bus->requestFrom(I2C_ADDRESS, (uint8_t) (READ_STATUS_LENGTH + READ_PRESSURE_LENGTH + READ_TEMPERATURE_LENGTH));
+            // Read the 8-bit status data.
+            status = bus->read();
+            if (isError(status)) {
+                // An ALU or memory error occurred.
+                bus->endTransmission();
+                goto error;
+            }
+            if (isBusy(status)) {
+                // The sensor is still busy; either retry or fail.
+                bus->endTransmission();
+                if (wait) {
+                // Wait just a bit so that we don't completely hammer the bus with retries.
+                _delay_us(100);
+                goto try_again;
+                }
+                goto error;
+            }
+            // Read the 24-bit (high 16-18 bits defined) of raw pressure data.
+            *((uint8_t *)(&raw_p)+2) = bus->read();
+            *((uint8_t *)(&raw_p)+1) = bus->read();
+            *((uint8_t *)(&raw_p)+0) = bus->read();
 
-    goto error;
-  }
+            // Read the 24-bit (high 16 bits defined) of raw temperature data.
+            *((uint8_t *)(&raw_t)+2) = bus->read();
+            *((uint8_t *)(&raw_t)+1) = bus->read();
+            *((uint8_t *)(&raw_t)+0) = bus->read();
 
-  // Read the 24-bit (high 16-18 bits defined) of raw pressure data.
-  *((uint8_t *)(&raw_p)+2) = bus->read();
-  *((uint8_t *)(&raw_p)+1) = bus->read();
-  *((uint8_t *)(&raw_p)+0) = bus->read();
+            bus->endTransmission();
 
-  // Read the 24-bit (high 16 bits defined) of raw temperature data.
-  *((uint8_t *)(&raw_t)+2) = bus->read();
-  *((uint8_t *)(&raw_t)+1) = bus->read();
-  *((uint8_t *)(&raw_t)+0) = bus->read();
-  
-  bus->endTransmission();
-
-  pressure = convertPressure(transferPressure(raw_p & pressure_resolution_mask));
-  temperature = convertTemperature(transferTemperature(raw_t & temperature_resolution_mask));
-
-  return isError(status);
+            pressure = convertPressure(transferPressure(raw_p & pressure_resolution_mask));
+            temperature = convertTemperature(transferTemperature(raw_t & temperature_resolution_mask));
+            return isError(status);
+        }
 
 error:
   pressure = NAN;
@@ -110,3 +245,165 @@ error:
   return true;
 }
 
+
+bool AllSensors_DLHR::readDataAsynchro(MeasurementType measurement_type){
+   bool dataReady = false;
+   
+   switch (this->state){
+      case State::STATE0:
+        startMeasurement(measurement_type);  //start conversion
+        this->state = State::STATE1;
+        break;
+
+      case State::STATE1:
+        bus->requestFrom(I2C_ADDRESS, (uint8_t) (READ_STATUS_LENGTH));// + READ_PRESSURE_LENGTH + READ_TEMPERATURE_LENGTH));
+         // Read the 8-bit status data.
+          status = bus->read();
+        if (isError(status)) {
+          // An ALU or memory error occurred.
+          bus->endTransmission();
+              this->pressure = NAN;
+              this->temperature = NAN;
+              this->state = State::STATE0;
+              dataReady = true;
+              break;
+        }
+        if (isBusy(status)) {
+          // The sensor is still busy; either retry or fail.
+          bus->endTransmission();
+        }
+        else{
+          bus->endTransmission();
+          this->state = State::STATE2;
+        }
+        break;
+
+
+      case State::STATE2:
+          bus->requestFrom(I2C_ADDRESS, (uint8_t) (READ_STATUS_LENGTH + READ_PRESSURE_LENGTH + READ_TEMPERATURE_LENGTH));
+          status = bus->read();
+          // Read the 24-bit (high 16-18 bits defined) of raw pressure data.
+          *((uint8_t *)(&raw_p)+2) = bus->read();
+          *((uint8_t *)(&raw_p)+1) = bus->read();
+          *((uint8_t *)(&raw_p)+0) = bus->read();
+
+          // Read the 24-bit (high 16 bits defined) of raw temperature data.
+          *((uint8_t *)(&raw_t)+2) = bus->read();
+          *((uint8_t *)(&raw_t)+1) = bus->read();
+          *((uint8_t *)(&raw_t)+0) = bus->read();
+          
+          bus->endTransmission();
+
+          this->pressure = convertPressure(transferPressure(raw_p & pressure_resolution_mask));
+          this->temperature = convertTemperature(transferTemperature(raw_t & temperature_resolution_mask));
+          this->state = State::STATE0;
+          dataReady = true;
+        break;
+   }
+  return dataReady;
+}
+
+
+
+
+
+
+bool AllSensors_DLHR::readDataAsynchro_V2(MeasurementType measurement_type){
+   bool dataReady = false;
+   
+   switch (this->state){
+      case State::STATE0:
+        startMeasurement(measurement_type);  //start conversion
+        this->state = State::STATE1;
+        break;
+
+      case State::STATE1:
+        if(bus==NULL){//spi mode
+              SPI.beginTransaction (SPISettings (2000000, MSBFIRST, SPI_MODE0));
+              digitalWrite (this->_cs, LOW);
+              status = SPI.transfer(0xF0); 
+              if (isError(status)) {
+                  // An ALU or memory error occurred.
+                  digitalWrite (this->_cs, HIGH);
+                  SPI.endTransaction();
+                    this->pressure = NAN;
+                    this->temperature = NAN;
+                    this->state = State::STATE0;
+                    dataReady = true;
+                    break;
+              }
+              if (isBusy(status)) {
+                // The sensor is still busy; either retry or fail.
+                digitalWrite (this->_cs, HIGH);
+                SPI.endTransaction();
+              }
+              else{
+                  digitalWrite (this->_cs, HIGH);
+                  SPI.endTransaction();
+                this->state = State::STATE2;
+              }
+              break;
+        }
+        else{//i2c mode
+              bus->requestFrom(I2C_ADDRESS, (uint8_t) (READ_STATUS_LENGTH));
+              // Read the 8-bit status data.
+              status = bus->read();
+              if (isError(status)) {
+                // An ALU or memory error occurred.
+                bus->endTransmission();
+                    this->pressure = NAN;
+                    this->temperature = NAN;
+                    this->state = State::STATE0;
+                    dataReady = true;
+                    break;
+              }
+              if (isBusy(status)) {
+                // The sensor is still busy; either retry or fail.
+                bus->endTransmission();
+              }
+              else{
+                bus->endTransmission();
+                this->state = State::STATE2;
+              }
+            break;
+        }
+        
+      case State::STATE2:
+        if(bus==NULL){//spi mode
+              SPI.beginTransaction (SPISettings (2000000, MSBFIRST, SPI_MODE0));
+              digitalWrite (this->_cs, LOW);
+              status = SPI.transfer(0xF0);
+              *((uint8_t *)(&raw_p)+2) = SPI.transfer(0x00);
+              *((uint8_t *)(&raw_p)+1) = SPI.transfer(0x00);
+              *((uint8_t *)(&raw_p)+0) = SPI.transfer(0x00);
+
+              // Read the 24-bit (high 16 bits defined) of raw temperature data.
+              *((uint8_t *)(&raw_t)+2) = SPI.transfer(0x00);
+              *((uint8_t *)(&raw_t)+1) = SPI.transfer(0x00);
+              *((uint8_t *)(&raw_t)+0) = SPI.transfer(0x00);
+              digitalWrite (this->_cs, HIGH);
+              SPI.endTransaction() ;
+          }
+        else{//i2c mode
+              bus->requestFrom(I2C_ADDRESS, (uint8_t) (READ_STATUS_LENGTH + READ_PRESSURE_LENGTH + READ_TEMPERATURE_LENGTH));
+              status = bus->read();
+              // Read the 24-bit (high 16-18 bits defined) of raw pressure data.
+              *((uint8_t *)(&raw_p)+2) = bus->read();
+              *((uint8_t *)(&raw_p)+1) = bus->read();
+              *((uint8_t *)(&raw_p)+0) = bus->read();
+
+              // Read the 24-bit (high 16 bits defined) of raw temperature data.
+              *((uint8_t *)(&raw_t)+2) = bus->read();
+              *((uint8_t *)(&raw_t)+1) = bus->read();
+              *((uint8_t *)(&raw_t)+0) = bus->read();
+              
+              bus->endTransmission();
+            }
+          this->pressure = convertPressure(transferPressure(raw_p & pressure_resolution_mask));
+          this->temperature = convertTemperature(transferTemperature(raw_t & temperature_resolution_mask));
+          this->state = State::STATE0;
+          dataReady = true;
+        break;
+   }
+  return dataReady;
+}

--- a/src/AllSensors_DLHR.cpp
+++ b/src/AllSensors_DLHR.cpp
@@ -47,9 +47,11 @@ AllSensors_DLHR::AllSensors_DLHR(TwoWire *bus, SensorType type, SensorResolution
 }
 
 
-AllSensors_DLHR::AllSensors_DLHR(uint8_t spi_cs, uint8_t spi_mosi,
-                                     uint8_t spi_miso, uint8_t spi_clk, SensorType type, SensorResolution pressure_resolution, float pressure_max)
-    : temperature_unit(TemperatureUnit::CELCIUS) {
+AllSensors_DLHR::AllSensors_DLHR(uint8_t spi_cs, uint8_t spi_mosi, uint8_t spi_miso, uint8_t spi_clk, 
+                                 SensorType type, SensorResolution pressure_resolution, float pressure_max) :
+  pressure_unit(PressureUnit::IN_H2O),     
+  temperature_unit(TemperatureUnit::CELCIUS)
+{
         this->_cs = spi_cs;
         this->_mosi = spi_mosi;
         this->_miso = spi_miso;
@@ -81,7 +83,10 @@ AllSensors_DLHR::AllSensors_DLHR(uint8_t spi_cs, uint8_t spi_mosi,
 }
 
 
-AllSensors_DLHR::AllSensors_DLHR(uint8_t spi_cs, SensorType type, SensorResolution pressure_resolution, float pressure_max):temperature_unit(TemperatureUnit::CELCIUS){
+AllSensors_DLHR::AllSensors_DLHR(uint8_t spi_cs, SensorType type, SensorResolution pressure_resolution, float pressure_max):
+  pressure_unit(PressureUnit::IN_H2O),     
+  temperature_unit(TemperatureUnit::CELCIUS)
+{
     this->_cs = spi_cs;
     this->bus = NULL;
     this->type = type;

--- a/src/AllSensors_DLHR.cpp
+++ b/src/AllSensors_DLHR.cpp
@@ -250,70 +250,7 @@ error:
   return true;
 }
 
-
 bool AllSensors_DLHR::readDataAsynchro(MeasurementType measurement_type){
-   bool dataReady = false;
-   
-   switch (this->state){
-      case State::STATE0:
-        startMeasurement(measurement_type);  //start conversion
-        this->state = State::STATE1;
-        break;
-
-      case State::STATE1:
-        bus->requestFrom(I2C_ADDRESS, (uint8_t) (READ_STATUS_LENGTH));// + READ_PRESSURE_LENGTH + READ_TEMPERATURE_LENGTH));
-         // Read the 8-bit status data.
-          status = bus->read();
-        if (isError(status)) {
-          // An ALU or memory error occurred.
-          bus->endTransmission();
-              this->pressure = NAN;
-              this->temperature = NAN;
-              this->state = State::STATE0;
-              dataReady = true;
-              break;
-        }
-        if (isBusy(status)) {
-          // The sensor is still busy; either retry or fail.
-          bus->endTransmission();
-        }
-        else{
-          bus->endTransmission();
-          this->state = State::STATE2;
-        }
-        break;
-
-
-      case State::STATE2:
-          bus->requestFrom(I2C_ADDRESS, (uint8_t) (READ_STATUS_LENGTH + READ_PRESSURE_LENGTH + READ_TEMPERATURE_LENGTH));
-          status = bus->read();
-          // Read the 24-bit (high 16-18 bits defined) of raw pressure data.
-          *((uint8_t *)(&raw_p)+2) = bus->read();
-          *((uint8_t *)(&raw_p)+1) = bus->read();
-          *((uint8_t *)(&raw_p)+0) = bus->read();
-
-          // Read the 24-bit (high 16 bits defined) of raw temperature data.
-          *((uint8_t *)(&raw_t)+2) = bus->read();
-          *((uint8_t *)(&raw_t)+1) = bus->read();
-          *((uint8_t *)(&raw_t)+0) = bus->read();
-          
-          bus->endTransmission();
-
-          this->pressure = convertPressure(transferPressure(raw_p & pressure_resolution_mask));
-          this->temperature = convertTemperature(transferTemperature(raw_t & temperature_resolution_mask));
-          this->state = State::STATE0;
-          dataReady = true;
-        break;
-   }
-  return dataReady;
-}
-
-
-
-
-
-
-bool AllSensors_DLHR::readDataAsynchro_V2(MeasurementType measurement_type){
    bool dataReady = false;
    
    switch (this->state){

--- a/src/AllSensors_DLHR.h
+++ b/src/AllSensors_DLHR.h
@@ -27,12 +27,16 @@ See the LICENSE file for more details.
 
 */
 
+//25-04-2022: modified for multiple i2c sensors: Sylvain Boyer
+//25-04-2022: 
+
 #ifndef ALLSENSORS_DLHR_H
 #define ALLSENSORS_DLHR_H
 
 #include <stdint.h>
 
 #include <Wire.h>
+#include <SPI.h>
 
 class AllSensors_DLHR {
 public:
@@ -87,7 +91,15 @@ public:
     KELVIN     = 'K',
   };
 
+  enum State{
+    STATE0 = 0,
+    STATE1 = 1,
+    STATE2 = 2,
+  };
+
 private:
+  //SPI bus pin config
+  uint8_t _cs, _sck, _mosi, _miso;
 
   // The length of the status information in the I2C response.
   static const uint8_t READ_STATUS_LENGTH = 1;
@@ -116,6 +128,7 @@ private:
   float pressure_zero_ref;
   PressureUnit pressure_unit;
   TemperatureUnit temperature_unit;
+  State state;
 
   // Convert a raw digital pressure read from the sensor to a floating point value in inH2O.
   float transferPressure(unsigned long raw_value) {
@@ -177,7 +190,18 @@ public:
     return (status_arg & (StatusFlags::ERROR_MEMORY | StatusFlags::ERROR_ALU)) != 0;
   }
 
+ //Constructors
+  //i2c
   AllSensors_DLHR(TwoWire *bus, SensorType type, SensorResolution pressure_resolution, float pressure_max);
+  //software-spi
+  AllSensors_DLHR(uint8_t spi_cs, uint8_t spi_mosi, uint8_t spi_miso,
+                uint8_t spi_clk, SensorType type, SensorResolution pressure_resolution, float pressure_max);
+  //hardware spi
+  AllSensors_DLHR(uint8_t spi_cs, SensorType type, SensorResolution pressure_resolution, float pressure_max);
+
+
+  //begin
+  bool begin(void);
 
   // Set the configured pressure unit for data output (the default is inH2O).
   void setPressureUnit(PressureUnit pressure_unit) {
@@ -211,6 +235,13 @@ public:
   // no longer busy. If wait is false, if the sensor is busy return "true" immediately indicating that
   // data was not available. 
   bool readData(bool wait = true);
+
+  //Read Data as a state machine
+  bool readDataAsynchro(MeasurementType measurement_type = MeasurementType::SINGLE);
+
+  //for debugging
+  bool readDataAsynchro_V2(MeasurementType measurement_type = MeasurementType::SINGLE);
+
 };
 
 #include "AllSensors_DLHR_subclasses.h"

--- a/src/AllSensors_DLHR.h
+++ b/src/AllSensors_DLHR.h
@@ -238,10 +238,6 @@ public:
 
   //Read Data as a state machine
   bool readDataAsynchro(MeasurementType measurement_type = MeasurementType::SINGLE);
-
-  //for debugging
-  bool readDataAsynchro_V2(MeasurementType measurement_type = MeasurementType::SINGLE);
-
 };
 
 #include "AllSensors_DLHR_subclasses.h"

--- a/src/AllSensors_DLHR_subclasses.h
+++ b/src/AllSensors_DLHR_subclasses.h
@@ -3,6 +3,10 @@
 #ifndef ALLSENSORS_DLHR_SUBCLASSES_H
 #define ALLSENSORS_DLHR_SUBCLASSES_H
 
+#include <AllSensors_DLHR.h>
+
+
+//i2c definitions
 class AllSensors_DLHR_F05D_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_F05D_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 0.5) {}
@@ -16,6 +20,7 @@ public:
 class AllSensors_DLHR_F05D_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_F05D_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 0.5) {}
+  AllSensors_DLHR_F05D_8(uint8_t cs_pin):AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 0.5) {}
 };
 
 class AllSensors_DLHR_F05G_6 : public AllSensors_DLHR {
@@ -242,5 +247,6 @@ class AllSensors_DLHR_L60G_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L60G_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 60.0) {}
 };
+
 
 #endif // ALLSENSORS_DLHR_SUBCLASSES_H

--- a/src/AllSensors_DLHR_subclasses.h
+++ b/src/AllSensors_DLHR_subclasses.h
@@ -3,250 +3,340 @@
 #ifndef ALLSENSORS_DLHR_SUBCLASSES_H
 #define ALLSENSORS_DLHR_SUBCLASSES_H
 
-#include <AllSensors_DLHR.h>
-
-
-//i2c definitions
 class AllSensors_DLHR_F05D_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_F05D_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 0.5) {}
+  AllSensors_DLHR_F05D_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 0.5) {}
+  AllSensors_DLHR_F05D_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 0.5) {}
 };
 
 class AllSensors_DLHR_F05D_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_F05D_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 0.5) {}
+  AllSensors_DLHR_F05D_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 0.5) {}
+  AllSensors_DLHR_F05D_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 0.5) {}
 };
 
 class AllSensors_DLHR_F05D_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_F05D_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 0.5) {}
-  AllSensors_DLHR_F05D_8(uint8_t cs_pin):AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 0.5) {}
+  AllSensors_DLHR_F05D_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 0.5) {}
+  AllSensors_DLHR_F05D_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 0.5) {}
 };
 
 class AllSensors_DLHR_F05G_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_F05G_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 0.5) {}
+  AllSensors_DLHR_F05G_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 0.5) {}
+  AllSensors_DLHR_F05G_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 0.5) {}
 };
 
 class AllSensors_DLHR_F05G_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_F05G_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 0.5) {}
+  AllSensors_DLHR_F05G_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 0.5) {}
+  AllSensors_DLHR_F05G_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 0.5) {}
 };
 
 class AllSensors_DLHR_F05G_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_F05G_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 0.5) {}
+  AllSensors_DLHR_F05G_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 0.5) {}
+  AllSensors_DLHR_F05G_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 0.5) {}
 };
 
 class AllSensors_DLHR_L01D_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L01D_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 1.0) {}
+  AllSensors_DLHR_L01D_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 1.0) {}
+  AllSensors_DLHR_L01D_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 1.0) {}
 };
 
 class AllSensors_DLHR_L01D_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L01D_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 1.0) {}
+  AllSensors_DLHR_L01D_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 1.0) {}
+  AllSensors_DLHR_L01D_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 1.0) {}
 };
 
 class AllSensors_DLHR_L01D_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L01D_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 1.0) {}
+  AllSensors_DLHR_L01D_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 1.0) {}
+  AllSensors_DLHR_L01D_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 1.0) {}
 };
 
 class AllSensors_DLHR_L01G_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L01G_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 1.0) {}
+  AllSensors_DLHR_L01G_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 1.0) {}
+  AllSensors_DLHR_L01G_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 1.0) {}
 };
 
 class AllSensors_DLHR_L01G_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L01G_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 1.0) {}
+  AllSensors_DLHR_L01G_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 1.0) {}
+  AllSensors_DLHR_L01G_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 1.0) {}
 };
 
 class AllSensors_DLHR_L01G_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L01G_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 1.0) {}
+  AllSensors_DLHR_L01G_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 1.0) {}
+  AllSensors_DLHR_L01G_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 1.0) {}
 };
 
 class AllSensors_DLHR_L02D_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L02D_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 2.0) {}
+  AllSensors_DLHR_L02D_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 2.0) {}
+  AllSensors_DLHR_L02D_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 2.0) {}
 };
 
 class AllSensors_DLHR_L02D_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L02D_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 2.0) {}
+  AllSensors_DLHR_L02D_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 2.0) {}
+  AllSensors_DLHR_L02D_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 2.0) {}
 };
 
 class AllSensors_DLHR_L02D_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L02D_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 2.0) {}
+  AllSensors_DLHR_L02D_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 2.0) {}
+  AllSensors_DLHR_L02D_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 2.0) {}
 };
 
 class AllSensors_DLHR_L02G_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L02G_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 2.0) {}
+  AllSensors_DLHR_L02G_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 2.0) {}
+  AllSensors_DLHR_L02G_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 2.0) {}
 };
 
 class AllSensors_DLHR_L02G_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L02G_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 2.0) {}
+  AllSensors_DLHR_L02G_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 2.0) {}
+  AllSensors_DLHR_L02G_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 2.0) {}
 };
 
 class AllSensors_DLHR_L02G_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L02G_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 2.0) {}
+  AllSensors_DLHR_L02G_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 2.0) {}
+  AllSensors_DLHR_L02G_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 2.0) {}
 };
 
 class AllSensors_DLHR_L05D_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L05D_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 5.0) {}
+  AllSensors_DLHR_L05D_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 5.0) {}
+  AllSensors_DLHR_L05D_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 5.0) {}
 };
 
 class AllSensors_DLHR_L05D_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L05D_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 5.0) {}
+  AllSensors_DLHR_L05D_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 5.0) {}
+  AllSensors_DLHR_L05D_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 5.0) {}
 };
 
 class AllSensors_DLHR_L05D_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L05D_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 5.0) {}
+  AllSensors_DLHR_L05D_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 5.0) {}
+  AllSensors_DLHR_L05D_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 5.0) {}
 };
 
 class AllSensors_DLHR_L05G_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L05G_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 5.0) {}
+  AllSensors_DLHR_L05G_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 5.0) {}
+  AllSensors_DLHR_L05G_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 5.0) {}
 };
 
 class AllSensors_DLHR_L05G_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L05G_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 5.0) {}
+  AllSensors_DLHR_L05G_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 5.0) {}
+  AllSensors_DLHR_L05G_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 5.0) {}
 };
 
 class AllSensors_DLHR_L05G_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L05G_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 5.0) {}
+  AllSensors_DLHR_L05G_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 5.0) {}
+  AllSensors_DLHR_L05G_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 5.0) {}
 };
 
 class AllSensors_DLHR_L10D_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L10D_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 10.0) {}
+  AllSensors_DLHR_L10D_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 10.0) {}
+  AllSensors_DLHR_L10D_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 10.0) {}
 };
 
 class AllSensors_DLHR_L10D_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L10D_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 10.0) {}
+  AllSensors_DLHR_L10D_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 10.0) {}
+  AllSensors_DLHR_L10D_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 10.0) {}
 };
 
 class AllSensors_DLHR_L10D_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L10D_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 10.0) {}
+  AllSensors_DLHR_L10D_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 10.0) {}
+  AllSensors_DLHR_L10D_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 10.0) {}
 };
 
 class AllSensors_DLHR_L10G_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L10G_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 10.0) {}
+  AllSensors_DLHR_L10G_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 10.0) {}
+  AllSensors_DLHR_L10G_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 10.0) {}
 };
 
 class AllSensors_DLHR_L10G_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L10G_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 10.0) {}
+  AllSensors_DLHR_L10G_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 10.0) {}
+  AllSensors_DLHR_L10G_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 10.0) {}
 };
 
 class AllSensors_DLHR_L10G_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L10G_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 10.0) {}
+  AllSensors_DLHR_L10G_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 10.0) {}
+  AllSensors_DLHR_L10G_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 10.0) {}
 };
 
 class AllSensors_DLHR_L20D_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L20D_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 20.0) {}
+  AllSensors_DLHR_L20D_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 20.0) {}
+  AllSensors_DLHR_L20D_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 20.0) {}
 };
 
 class AllSensors_DLHR_L20D_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L20D_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 20.0) {}
+  AllSensors_DLHR_L20D_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 20.0) {}
+  AllSensors_DLHR_L20D_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 20.0) {}
 };
 
 class AllSensors_DLHR_L20D_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L20D_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 20.0) {}
+  AllSensors_DLHR_L20D_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 20.0) {}
+  AllSensors_DLHR_L20D_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 20.0) {}
 };
 
 class AllSensors_DLHR_L20G_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L20G_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 20.0) {}
+  AllSensors_DLHR_L20G_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 20.0) {}
+  AllSensors_DLHR_L20G_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 20.0) {}
 };
 
 class AllSensors_DLHR_L20G_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L20G_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 20.0) {}
+  AllSensors_DLHR_L20G_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 20.0) {}
+  AllSensors_DLHR_L20G_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 20.0) {}
 };
 
 class AllSensors_DLHR_L20G_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L20G_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 20.0) {}
+  AllSensors_DLHR_L20G_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 20.0) {}
+  AllSensors_DLHR_L20G_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 20.0) {}
 };
 
 class AllSensors_DLHR_L30D_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L30D_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 30.0) {}
+  AllSensors_DLHR_L30D_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 30.0) {}
+  AllSensors_DLHR_L30D_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 30.0) {}
 };
 
 class AllSensors_DLHR_L30D_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L30D_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 30.0) {}
+  AllSensors_DLHR_L30D_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 30.0) {}
+  AllSensors_DLHR_L30D_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 30.0) {}
 };
 
 class AllSensors_DLHR_L30D_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L30D_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 30.0) {}
+  AllSensors_DLHR_L30D_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 30.0) {}
+  AllSensors_DLHR_L30D_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 30.0) {}
 };
 
 class AllSensors_DLHR_L30G_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L30G_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 30.0) {}
+  AllSensors_DLHR_L30G_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 30.0) {}
+  AllSensors_DLHR_L30G_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 30.0) {}
 };
 
 class AllSensors_DLHR_L30G_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L30G_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 30.0) {}
+  AllSensors_DLHR_L30G_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 30.0) {}
+  AllSensors_DLHR_L30G_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 30.0) {}
 };
 
 class AllSensors_DLHR_L30G_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L30G_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 30.0) {}
+  AllSensors_DLHR_L30G_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 30.0) {}
+  AllSensors_DLHR_L30G_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 30.0) {}
 };
 
 class AllSensors_DLHR_L60D_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L60D_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 60.0) {}
+  AllSensors_DLHR_L60D_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 60.0) {}
+  AllSensors_DLHR_L60D_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 60.0) {}
 };
 
 class AllSensors_DLHR_L60D_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L60D_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 60.0) {}
+  AllSensors_DLHR_L60D_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 60.0) {}
+  AllSensors_DLHR_L60D_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 60.0) {}
 };
 
 class AllSensors_DLHR_L60D_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L60D_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 60.0) {}
+  AllSensors_DLHR_L60D_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 60.0) {}
+  AllSensors_DLHR_L60D_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::DIFFERENTIAL, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 60.0) {}
 };
 
 class AllSensors_DLHR_L60G_6 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L60G_6(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 60.0) {}
+  AllSensors_DLHR_L60G_6(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 60.0) {}
+  AllSensors_DLHR_L60G_6(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_16_BITS, 60.0) {}
 };
 
 class AllSensors_DLHR_L60G_7 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L60G_7(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 60.0) {}
+  AllSensors_DLHR_L60G_7(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 60.0) {}
+  AllSensors_DLHR_L60G_7(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_17_BITS, 60.0) {}
 };
 
 class AllSensors_DLHR_L60G_8 : public AllSensors_DLHR {
 public:
   AllSensors_DLHR_L60G_8(TwoWire *bus) : AllSensors_DLHR(bus, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 60.0) {}
+  AllSensors_DLHR_L60G_8(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 60.0) {}
+  AllSensors_DLHR_L60G_8(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, AllSensors_DLHR::SensorType::GAGE, AllSensors_DLHR::SensorResolution::RESOLUTION_18_BITS, 60.0) {}
 };
-
 
 #endif // ALLSENSORS_DLHR_SUBCLASSES_H

--- a/util/generate_AllSensors_DLHR_subclasses.rb
+++ b/util/generate_AllSensors_DLHR_subclasses.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!ruby
 #
 # This software is licensed under the Revised (3-clause) BSD license as follows:
 #
@@ -50,6 +50,8 @@ RANGES.sort.each do |range_name, range_value|
       puts "class #{class_name} : public AllSensors_DLHR {"
       puts "public:"
       puts "  #{class_name}(TwoWire *bus) : AllSensors_DLHR(bus, #{type_value}, #{resolution_value}, #{range_value}) {}"
+      puts "  #{class_name}(uint8_t cs_pin) : AllSensors_DLHR(cs_pin, #{type_value}, #{resolution_value}, #{range_value}) {}"
+      puts "  #{class_name}(uint8_t cs_pin, uint8_t mosi_pin, uint8_t miso_pin,uint8_t clk_pin) : AllSensors_DLHR(cs_pin, mosi_pin, miso_pin, clk_pin, #{type_value}, #{resolution_value}, #{range_value}) {}"
       puts "};"
       puts
     end


### PR DESCRIPTION
Dear Jeremy, 
Thank you for having provided a very good base library for the AllSensor DLHR. As my application require multiple differential pressure sensors, I have adapted the library to include: 
1) SPI readings, for Sensors that have dedicated packages
2) Asynchronous reading to pull data from multiple sensors. This uses a state machine
3) Examples to use either i2c and spi

note the SPI require to add the begin() function.

The code has been tested with:
For the i2c example: Arduino Uno + TCA9548A + AllSensors DLHR-F50D-E1BD-I-NAV8  (x2)
For the spi example: Arduino nano + AllSensors DLHR-F50D-E1BD-I-NAV8 (x4)

Hope this branch is stable and can help further works.

Sincerely, 

Sylvain